### PR TITLE
Feature/elfeed

### DIFF
--- a/karakeep-send.el
+++ b/karakeep-send.el
@@ -1,3 +1,4 @@
+;; -*- lexical-binding: t; -*-
 ;; Copyright (C) 2022-2025  Free Software Foundation, Inc.
 
 ;; Author: Summer Emacs <summeremacs@summerstar.me>

--- a/karakeep-send.el
+++ b/karakeep-send.el
@@ -89,7 +89,7 @@ STATUS is the response status from url-retrieve."
     (message "⚠️ No valid Org link at point.")))
 
 ;; Send marked text
-(defun karakeep-send-marked-text ()
+(defun karakeep-send-region ()
   "Send the currently active region (marked text) to Karakeep as a 'text' type."
   (interactive)
   (if (use-region-p)
@@ -106,9 +106,8 @@ STATUS is the response status from url-retrieve."
     (message "⚠️ No active region (marked text).")))
 
 
-(defun elfeed-star-and-send-to-karakeep ()
-  "Star the current Elfeed entry and send it to Karakeep.
-Works in both elfeed-search-mode and elfeed-show-mode."
+(defun karakeep-send-elfeed-entry ()
+  "Star the current Elfeed entry and send it to Karakeep."
   (interactive)
   (let* ((entry (if (eq major-mode 'elfeed-show-mode)
                     elfeed-show-entry


### PR DESCRIPTION
1. Adds =lexical-binding: t= to the file header
2. Extracts response handling logic into a dedicated =karakeep--handle-response= function, reducing code duplication
3. Renames =karakeep-send-marked-text= to the more idiomatic =karakeep-send-region= (aligns with Emacs naming conventions)
4. Adds a new =karakeep-send-elfeed-entry= function that integrates with elfeed, allowing users to both star entries and send them to Karakeep in one step
5. Improves error and success messages to be more consistent